### PR TITLE
Update Permutations.hs

### DIFF
--- a/Control/Applicative/Permutations.hs
+++ b/Control/Applicative/Permutations.hs
@@ -1,4 +1,4 @@
-﻿-- |
+-- |
 -- Module      :  Control.Applicative.Permutations
 -- Copyright   :  © 2017 Mark Karpov
 -- License     :  BSD 3 clause


### PR DESCRIPTION
Byte order markings cause breakage on some systems and GHC versions, e.g. `x86_64-openbsd-ghc-7.10.3`:
```
ylh@vbox:/tmp/parser-combinators-0.2.0/Control/Applicative$ ghc Permutations.hs

Permutations.hs:1:1: lexical error at character '\65279'
```
Moreover, is it pointless in UTF-8 -- There is only one byte order possible.