### PR TITLE
Minor Permutation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Parser combinators 1.0.2
+
+* Defined `liftA2` for `Permutation` manually. The new definition should be
+  more efficient.
+
+* Made inner `Maybe` field in `Permutation` strict.
+
 ## Parser combinators 1.0.1
 
 * Cosmetic changes in the source code.

--- a/Control/Applicative/Permutations.hs
+++ b/Control/Applicative/Permutations.hs
@@ -40,6 +40,8 @@
 --
 -- @since 0.2.0
 
+{-# LANGUAGE CPP #-}
+
 module Control.Applicative.Permutations
   ( -- ** Permutation type
     Permutation
@@ -66,6 +68,12 @@ instance Alternative m => Applicative (Permutation m) where
     where
       lhsAlt = (<*> rhs) <$> v
       rhsAlt = (lhs <*>) <$> w
+#if MIN_VERSION_base(4,10,0)
+  liftA2 f lhs@(P x v) rhs@(P y w) = P (liftA2 f x y) (lhsAlt <|> rhsAlt)
+    where
+      lhsAlt = (\p -> liftA2 f p rhs) <$> v
+      rhsAlt = liftA2 f lhs <$> w
+#endif
 
 -- | \"Unlifts\" a permutation parser into a parser to be evaluated.
 

--- a/Control/Applicative/Permutations.hs
+++ b/Control/Applicative/Permutations.hs
@@ -55,7 +55,7 @@ import Control.Applicative
 
 -- | An 'Applicative' wrapper-type for constructing permutation parsers.
 
-data Permutation m a = P (Maybe a) (m (Permutation m a))
+data Permutation m a = P !(Maybe a) (m (Permutation m a))
 
 instance Functor m => Functor (Permutation m) where
   fmap f (P v p) = P (f <$> v) (fmap f <$> p)


### PR DESCRIPTION
* Make `Permutation` strict in the `Maybe` default.

* Define `liftA2` when appropriate.

Fixes #17