### PR TITLE
Add support for ternary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added a test suite as a separate package called
   `parser-combinators-tests`.
 
+* Added support for ternary operators; see `TernR` in
+    `Control.Monad.Combinators.Expr`.
+
 ## Parser combinators 1.0.2
 
 * Defined `liftA2` for `Permutation` manually. The new definition should be


### PR DESCRIPTION
Hey Mark,

The ternary operator is a common language construct, so it would be nice to support it here. (I originally implemented this for patterns in tasty, and now we also needed this for one of the clients.)