### PR TITLE
Correct an infelicity in the documentation of 'skipCount'

### DIFF
--- a/Control/Applicative/Combinators.hs
+++ b/Control/Applicative/Combinators.hs
@@ -315,8 +315,7 @@ skipSome p = p *> skipMany p
 {-# INLINE skipSome #-}
 
 -- | @'skipCount' n p@ parses @n@ occurrences of @p@, skipping its result.
--- If @n@ is not positive, the parser equals to @'pure' []@. Returns a list
--- of @n@ values.
+-- If @n@ is not positive, the parser equals to @'pure' ()@.
 --
 -- > skipCount = replicateM_
 --

--- a/Control/Monad/Combinators.hs
+++ b/Control/Monad/Combinators.hs
@@ -300,8 +300,7 @@ skipSome p = p >> skipMany p
 {-# INLINE skipSome #-}
 
 -- | @'skipCount' n p@ parses @n@ occurrences of @p@, skipping its result.
--- If @n@ is smaller or equal to zero, the parser equals to @'return' []@.
--- Returns a list of @n@ values.
+-- If @n@ is smaller or equal to zero, the parser equals to @'return' ()@.
 --
 -- See also: 'count', 'count''.
 


### PR DESCRIPTION
I was browsing the Hackage documentation and noticed that the doc comment for `skipCount` did not match its type signature.