### PR TITLE
Redefining permutation parser interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Parser combinators 1.3.0
+
+* Changed the `Control.Applicative.Permutations` module to only require
+  `Applicative` and not `Monad`. This module is the least restrictive and works
+  with parsers which are not `Monad`s.
+
+* Added the `Control.Monad.Permutations` module. This module may be
+  substantially more efficient for some parsers which are `Monad`s.
+
+* Corrected how permutation parsers intercalate effects and components; parsing
+  an effect requires that a component immediately follows or else a parse error
+  will result.
+
 ## Parser combinators 1.2.1
 
 * The tests in `parser-combinators-tests` now work with Megaparsec 8.

--- a/Control/Monad/Permutations.hs
+++ b/Control/Monad/Permutations.hs
@@ -1,0 +1,104 @@
+-- |
+-- Module      :  Control.Monad.Permutations
+-- Copyright   :  © 2017–present Alex Washburn
+-- License     :  BSD 3 clause
+--
+-- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- This module specialized the interface to 'Monad' for potential efficiency
+-- considerations, depending on the monad the permutations are run over.
+--
+-- For a more general interface requiring only 'Applicative', and for more
+-- complete documentation, see the 'Control.Applicative.Permutations' module.
+--
+-- @since 1.3.0
+module Control.Monad.Permutations
+  ( -- ** Permutation type
+    Permutation,
+
+    -- ** Permutation evaluators
+    runPermutation,
+    intercalateEffect,
+
+    -- ** Permutation constructors
+    toPermutation,
+    toPermutationWithDefault,
+  )
+where
+
+import Control.Applicative
+
+-- | An 'Applicative' wrapper-type for constructing permutation parsers.
+data Permutation m a = P !(Maybe a) (m (Permutation m a))
+
+instance Functor m => Functor (Permutation m) where
+  fmap f (P v p) = P (f <$> v) (fmap f <$> p)
+
+instance Alternative m => Applicative (Permutation m) where
+  pure value = P (Just value) empty
+  lhs@(P f v) <*> rhs@(P g w) = P (f <*> g) (lhsAlt <|> rhsAlt)
+    where
+      lhsAlt = (<*> rhs) <$> v
+      rhsAlt = (lhs <*>) <$> w
+  liftA2 f lhs@(P x v) rhs@(P y w) = P (liftA2 f x y) (lhsAlt <|> rhsAlt)
+    where
+      lhsAlt = (\p -> liftA2 f p rhs) <$> v
+      rhsAlt = liftA2 f lhs <$> w
+
+-- | \"Unlifts\" a permutation parser into a parser to be evaluated.
+runPermutation ::
+  ( Alternative m,
+    Monad m
+  ) =>
+  -- | Permutation specification
+  Permutation m a ->
+  -- | Resulting base monad capable of handling the permutation
+  m a
+runPermutation (P value parser) = optional parser >>= f
+  where
+    f Nothing = maybe empty pure value
+    f (Just p) = runPermutation p
+
+-- | \"Unlifts\" a permutation parser into a parser to be evaluated with an
+-- intercalated effect. Useful for separators between permutation elements.
+intercalateEffect ::
+  ( Alternative m,
+    Monad m
+  ) =>
+  -- | Effect to be intercalated between permutation components
+  m b ->
+  -- | Permutation specification
+  Permutation m a ->
+  -- | Resulting base monad capable of handling the permutation
+  m a
+intercalateEffect = run noEffect
+  where
+    noEffect = pure ()
+    run :: (Alternative m, Monad m) => m c -> m b -> Permutation m a -> m a
+    run headSep tailSep (P value parser) = optional (headSep *> parser) >>= f
+      where
+        f Nothing = maybe empty pure value
+        f (Just p) = run tailSep tailSep p
+
+-- | \"Lifts\" a parser to a permutation parser.
+toPermutation ::
+  Alternative m =>
+  -- | Permutation component
+  m a ->
+  Permutation m a
+toPermutation p = P Nothing $ pure <$> p
+
+-- | \"Lifts\" a parser with a default value to a permutation parser.
+--
+-- If no permutation containing the supplied parser can be parsed from the input,
+-- then the supplied default value is returned in lieu of a parse result.
+toPermutationWithDefault ::
+  Alternative m =>
+  -- | Default Value
+  a ->
+  -- | Permutation component
+  m a ->
+  Permutation m a
+toPermutationWithDefault v p = P (Just v) $ pure <$> p

--- a/parser-combinators-tests/parser-combinators-tests.cabal
+++ b/parser-combinators-tests/parser-combinators-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version:   1.18
 name:            parser-combinators-tests
-version:         1.2.1
+version:         1.3.0
 license:         BSD3
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
@@ -23,7 +23,7 @@ flag dev
     default:     False
     manual:      True
 
-test-suite tests
+test-suite test-suite
     type:             exitcode-stdio-1.0
     main-is:          Spec.hs
     build-tools:      hspec-discover >=2.0 && <3.0
@@ -33,6 +33,7 @@ test-suite tests
         Control.Applicative.PermutationsSpec
         Control.Monad.Combinators.ExprSpec
         Control.Monad.CombinatorsSpec
+        Control.Monad.PermutationsSpec
 
     default-language: Haskell2010
     build-depends:
@@ -43,7 +44,7 @@ test-suite tests
         hspec-megaparsec >=2.0 && <3.0,
         megaparsec >=8.0 && <10.0,
         megaparsec-tests >=8.0 && <10.0,
-        parser-combinators ==1.2.1
+        parser-combinators ==1.3.0
 
     if flag(dev)
         ghc-options: -Wall -Werror

--- a/parser-combinators-tests/tests/Control/Monad/PermutationsSpec.hs
+++ b/parser-combinators-tests/tests/Control/Monad/PermutationsSpec.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Control.Applicative.PermutationsSpec (spec) where
+module Control.Monad.PermutationsSpec (spec) where
 
-import Control.Applicative.Permutations
 import Control.Monad
+import Control.Monad.Permutations
 import Data.List
 import Data.Void
 import Test.Hspec

--- a/parser-combinators.cabal
+++ b/parser-combinators.cabal
@@ -1,6 +1,6 @@
 cabal-version:   1.18
 name:            parser-combinators
-version:         1.2.1
+version:         1.3.0
 license:         BSD3
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
@@ -40,6 +40,7 @@ library
         Control.Monad.Combinators
         Control.Monad.Combinators.Expr
         Control.Monad.Combinators.NonEmpty
+        Control.Monad.Permutations
 
     default-language: Haskell2010
     build-depends:    base >=4.12 && <5.0


### PR DESCRIPTION
I updated the `Control.Applicative.Permutations` module to only require an `Applicative` instance. This required a complete rewrite of the underlying code and data structures. As a result the code in this module may be less performant than previously so I have marked this as a breaking change in the `CHANGELOG.md` and `parser-combinators.cabal` files with a version  bump to `1.3.0`.

Since the original code is potentially more efficient depending on the underlying parser, I took that permutation parser code which relied on `Monad` instances and added it to the new module `Control.Monad.Permutations`. This is in line with the design philosophy of the `parser-combinators` library, as I understand it.

Close #33.