### PR TITLE
fix haddock markdown for module links

### DIFF
--- a/Control/Monad/Permutations.hs
+++ b/Control/Monad/Permutations.hs
@@ -11,7 +11,7 @@
 -- considerations, depending on the monad the permutations are run over.
 --
 -- For a more general interface requiring only 'Applicative', and for more
--- complete documentation, see the 'Control.Applicative.Permutations' module.
+-- complete documentation, see the "Control.Applicative.Permutations" module.
 --
 -- @since 1.3.0
 module Control.Monad.Permutations


### PR DESCRIPTION
Module links use double quotes, not single quotes.